### PR TITLE
Controlling page access based on time of day

### DIFF
--- a/src/components/common/AccessControl/AccessControl.tsx
+++ b/src/components/common/AccessControl/AccessControl.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+import { getCurrentEvent, eventTime } from '../../../utils/time';
+
+interface AccessControlProps {
+  page: eventTime;
+}
+
+const AccessControl = (
+  props: AccessControlProps,
+): React.ReactElement | null => {
+  // Only redirect if the time of day doesn't match the page passed in
+  return getCurrentEvent() === props.page ? null : <Redirect to="/dashboard" />;
+};
+
+export default AccessControl;

--- a/src/components/common/AccessControl/AccessControl.tsx
+++ b/src/components/common/AccessControl/AccessControl.tsx
@@ -3,14 +3,16 @@ import { Redirect } from 'react-router-dom';
 import { getCurrentEvent, eventTime } from '../../../utils/time';
 
 interface AccessControlProps {
-  page: eventTime;
+  event: eventTime;
 }
 
 const AccessControl = (
   props: AccessControlProps,
 ): React.ReactElement | null => {
-  // Only redirect if the time of day doesn't match the page passed in
-  return getCurrentEvent() === props.page ? null : <Redirect to="/dashboard" />;
+  // Only redirect if the time of day doesn't match the event passed in
+  return getCurrentEvent() === props.event ? null : (
+    <Redirect to="/dashboard" />
+  );
 };
 
 export default AccessControl;

--- a/src/components/common/AccessControl/index.js
+++ b/src/components/common/AccessControl/index.js
@@ -1,0 +1,1 @@
+export { default as AccessControl } from './AccessControl';

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -1,21 +1,45 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { NavLink, Link, useHistory } from 'react-router-dom';
 import { clearToken } from '../../../utils';
+import { getCurrentEvent } from '../../../utils/time';
 
 interface HeaderProps {
   title?: string;
 }
+interface RouteData {
+  route: string;
+  text: string;
+}
 
-const routes = [
-  { route: '/dashboard', text: 'Dashboard' },
-  { route: '/submission', text: 'Submit a Story' },
-  { route: '/voting', text: 'Vote' },
-  { route: '/winners', text: 'View Winners' },
-  { route: '/stream', text: 'Watch Stream' },
-];
+const dashRoute: RouteData = { route: '/dashboard', text: 'Dashboard' };
+const submitRoute: RouteData = { route: '/submission', text: 'Submit a Story' };
+const voteRoute: RouteData = { route: '/voting', text: 'Vote' };
+const streamRoute: RouteData = { route: '/stream', text: 'Watch Stream' };
+const winnerRoute: RouteData = { route: '/winners', text: 'View Winners' };
 
 const Header = ({ title = 'Story Squad' }: HeaderProps): React.ReactElement => {
   const { push } = useHistory();
+  const [timedRoute, setTimedRoute] = useState<null | RouteData>(null);
+
+  useEffect(() => {
+    switch (getCurrentEvent()) {
+      case 'SUBMIT':
+        setTimedRoute(submitRoute);
+        return;
+      case 'VOTE':
+        setTimedRoute(voteRoute);
+        return;
+      case 'STREAM':
+        setTimedRoute(streamRoute);
+        return;
+      case 'NONE':
+        setTimedRoute(winnerRoute);
+        return;
+      default:
+        setTimedRoute(null);
+        return;
+    }
+  }, []);
 
   const logout = () => {
     clearToken();
@@ -28,16 +52,21 @@ const Header = ({ title = 'Story Squad' }: HeaderProps): React.ReactElement => {
         <Link to="/dashboard">{title}</Link>
       </h2>
       <nav>
-        {routes.map((r, i) => (
-          <NavLink to={r.route} activeClassName="current" key={i}>
-            {r.text}
-          </NavLink>
-        ))}
+        <RouteLink {...dashRoute} />
+        {timedRoute && <RouteLink {...timedRoute} />}
         <span className="logout" onClick={logout}>
           Log Out
         </span>
       </nav>
     </header>
+  );
+};
+
+const RouteLink: React.FC<RouteData> = (route) => {
+  return (
+    <NavLink activeClassName="current" to={route.route}>
+      {route.text}
+    </NavLink>
   );
 };
 

--- a/src/components/common/index.js
+++ b/src/components/common/index.js
@@ -1,4 +1,3 @@
-import { Modal } from './Modal';
-import { Header } from './Header';
-
-export { Modal, Header };
+export { Modal } from './Modal';
+export { Header } from './Header';
+export { AccessControl } from './AccessControl';

--- a/src/components/pages/StreamPage/StreamPageContainer.tsx
+++ b/src/components/pages/StreamPage/StreamPageContainer.tsx
@@ -5,7 +5,7 @@ import RenderStreamPage from './RenderStreamPage';
 const StreamPageContainer: React.FC = () => {
   return (
     <>
-      <AccessControl page="STREAM" />
+      <AccessControl event="STREAM" />
       <RenderStreamPage />
     </>
   );

--- a/src/components/pages/StreamPage/StreamPageContainer.tsx
+++ b/src/components/pages/StreamPage/StreamPageContainer.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
+import { AccessControl } from '../../common';
 import RenderStreamPage from './RenderStreamPage';
 
 const StreamPageContainer: React.FC = () => {
-  return <RenderStreamPage />;
+  return (
+    <>
+      <AccessControl page="STREAM" />
+      <RenderStreamPage />
+    </>
+  );
 };
 
 export default StreamPageContainer;

--- a/src/components/pages/SubmissionPage/SubmissionPageContainer.tsx
+++ b/src/components/pages/SubmissionPage/SubmissionPageContainer.tsx
@@ -5,7 +5,7 @@ import RenderSubmissionPage from './RenderSubmissionPage';
 const SubmissionPageContainer: React.FC = () => {
   return (
     <>
-      <AccessControl page="SUBMIT" />
+      <AccessControl event="SUBMIT" />
       <RenderSubmissionPage />
     </>
   );

--- a/src/components/pages/SubmissionPage/SubmissionPageContainer.tsx
+++ b/src/components/pages/SubmissionPage/SubmissionPageContainer.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
+import { AccessControl } from '../../common';
 import RenderSubmissionPage from './RenderSubmissionPage';
 
 const SubmissionPageContainer: React.FC = () => {
-  return <RenderSubmissionPage />;
+  return (
+    <>
+      <AccessControl page="SUBMIT" />
+      <RenderSubmissionPage />
+    </>
+  );
 };
 
 export default SubmissionPageContainer;

--- a/src/components/pages/VotingPage/VotingPageContainer.tsx
+++ b/src/components/pages/VotingPage/VotingPageContainer.tsx
@@ -5,7 +5,7 @@ import RenderVotingPage from './RenderVotingPage';
 const VotingPageContainer: React.FC = () => {
   return (
     <>
-      <AccessControl page="VOTE" />
+      <AccessControl event="VOTE" />
       <RenderVotingPage />
     </>
   );

--- a/src/components/pages/VotingPage/VotingPageContainer.tsx
+++ b/src/components/pages/VotingPage/VotingPageContainer.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
+import { AccessControl } from '../../common';
 import RenderVotingPage from './RenderVotingPage';
 
 const VotingPageContainer: React.FC = () => {
-  return <RenderVotingPage />;
+  return (
+    <>
+      <AccessControl page="VOTE" />
+      <RenderVotingPage />
+    </>
+  );
 };
 
 export default VotingPageContainer;

--- a/src/components/pages/WinnersPage/WinnersPageContainer.tsx
+++ b/src/components/pages/WinnersPage/WinnersPageContainer.tsx
@@ -5,7 +5,7 @@ import RenderWinnersPage from './RenderWinnersPage';
 const WinnersPageContainer: React.FC = () => {
   return (
     <>
-      <AccessControl page="NONE" />
+      <AccessControl event="NONE" />
       <RenderWinnersPage />
     </>
   );

--- a/src/components/pages/WinnersPage/WinnersPageContainer.tsx
+++ b/src/components/pages/WinnersPage/WinnersPageContainer.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
+import { AccessControl } from '../../common';
 import RenderWinnersPage from './RenderWinnersPage';
 
 const WinnersPageContainer: React.FC = () => {
-  return <RenderWinnersPage />;
+  return (
+    <>
+      <AccessControl page="NONE" />
+      <RenderWinnersPage />
+    </>
+  );
 };
 
 export default WinnersPageContainer;

--- a/src/utils/time.tsx
+++ b/src/utils/time.tsx
@@ -44,7 +44,7 @@ const schedule = {
   interimEnd: makeScheduleTime(3, 30),
 };
 
-type eventTime = 'SUBMIT' | 'DELIB' | 'VOTE' | 'STREAM' | 'NONE';
+export type eventTime = 'SUBMIT' | 'DELIB' | 'VOTE' | 'STREAM' | 'NONE';
 export const getCurrentEvent = (time?: Moment): eventTime => {
   if (!time) time = moment();
   const now = time.utc().valueOf();


### PR DESCRIPTION
This requires a 2-part approach:

- [x] Conditionally rendering only specific elements in the navbar
- [x] Forcing pages to reroute to dashboard when someone attempts to access them at the wrong time
  - [x] ^ Achieve this by creating a component that conditionally renders a redirect based on time of day

This should be a fairly simple and maintainable approach as we only have to change the schedule times in the `time` module to adjust access.

I thought of a fix for the issue of the page changing if a component re-renders while a child is performing a task, but we should discuss if that's intended behavior or not, and how to handle it from a UX perspective.