### PR TITLE
Bug fix/drag and drop voting

### DIFF
--- a/src/components/pages/VotingPage/CastVote/CastVoteContainer.tsx
+++ b/src/components/pages/VotingPage/CastVote/CastVoteContainer.tsx
@@ -3,10 +3,9 @@ import { useRecoilState } from 'recoil';
 import { DnD } from '../../../../state/';
 import RenderCastVotes from './RenderCastVotes';
 import { DragDropContext, DragStart, DropResult } from 'react-beautiful-dnd';
-import { DnDContainerState } from '../../../../state/DnDState';
 
 const CastVoteContainer = (): React.ReactElement => {
-  const [DnDState, setDnDState] = useRecoilState<DnDContainerState>(
+  const [DnDState, setDnDState] = useRecoilState<DnD.DnDContainerState>(
     DnD.DnDContainerState,
   );
   /**

--- a/src/components/pages/VotingPage/CastVote/CastVoteContainer.tsx
+++ b/src/components/pages/VotingPage/CastVote/CastVoteContainer.tsx
@@ -5,9 +5,7 @@ import RenderCastVotes from './RenderCastVotes';
 import { DragDropContext, DragStart, DropResult } from 'react-beautiful-dnd';
 
 const CastVoteContainer = (): React.ReactElement => {
-  const [DnDState, setDnDState] = useRecoilState<DnD.DnDContainerState>(
-    DnD.DnDContainerState,
-  );
+  const [DnDState, setDnDState] = useRecoilState(DnD.DnDContainerState);
   /**
    * Callback used by React Beautiful DnD to update state at the beginning of a drag event.
    * This is being used to render the dragon outline image when a user starts dragging a dragon

--- a/src/components/pages/VotingPage/CastVote/CastVoteContainer.tsx
+++ b/src/components/pages/VotingPage/CastVote/CastVoteContainer.tsx
@@ -3,9 +3,12 @@ import { useRecoilState } from 'recoil';
 import { DnD } from '../../../../state/';
 import RenderCastVotes from './RenderCastVotes';
 import { DragDropContext, DragStart, DropResult } from 'react-beautiful-dnd';
+import { DnDContainerState } from '../../../../state/DnDState';
 
 const CastVoteContainer = (): React.ReactElement => {
-  const [DnDState, setDnDState] = useRecoilState(DnD.DnDContainerState);
+  const [DnDState, setDnDState] = useRecoilState<DnDContainerState>(
+    DnD.DnDContainerState,
+  );
   /**
    * Callback used by React Beautiful DnD to update state at the beginning of a drag event.
    * This is being used to render the dragon outline image when a user starts dragging a dragon
@@ -26,14 +29,6 @@ const CastVoteContainer = (): React.ReactElement => {
     const { source, destination, draggableId } = result;
     // if the draggable was dropped outside a droppable we don't need to do anything so return
     if (!destination) {
-      return;
-    }
-    // if the source id and index is the same as the destination id and index
-    // then it was moved around but then dropped back in the original spot
-    if (
-      source.droppableId === destination.droppableId &&
-      source.index === destination.index
-    ) {
       // update state to show the drop zone is once again occupied
       setDnDState({
         ...DnDState,
@@ -43,30 +38,47 @@ const CastVoteContainer = (): React.ReactElement => {
         },
       });
     }
-    // ref to destination state object
-    const finish = DnDState[destination.droppableId];
-    // if we have a destination and the destination contents are also empty we need
-    // to update state so the re-render will reflect the new placement of the elements
-    if (finish.isEmpty) {
-      // create a new source object of the updated contents and isEmpty
-      const newStart = {
-        contents: '',
-        isEmpty: true,
-      };
-      // create a new destination object of the updated contents and isEmpty
-      const newFinish = {
-        contents: draggableId,
-        isEmpty: false,
-      };
-      // update state with new state object
-      setDnDState({
-        // copy in the existing state object
-        ...DnDState,
-        // update the source contents
-        [source.droppableId]: newStart,
-        // update the destination contents
-        [destination.droppableId]: newFinish,
-      });
+    if (destination) {
+      // if the source id and index is the same as the destination id and index
+      // then it was moved around but then dropped back in the original spot
+      if (
+        source.droppableId === destination.droppableId &&
+        source.index === destination.index
+      ) {
+        // update state to show the drop zone is once again occupied
+        setDnDState({
+          ...DnDState,
+          [source.droppableId]: {
+            ...DnDState[source.droppableId],
+            isEmpty: false,
+          },
+        });
+      }
+      // ref to destination state object
+      const finish = DnDState[destination.droppableId];
+      // if we have a destination and the destination contents are also empty we need
+      // to update state so the re-render will reflect the new placement of the elements
+      if (finish.isEmpty) {
+        // create a new source object of the updated contents and isEmpty
+        const newStart = {
+          contents: '',
+          isEmpty: true,
+        };
+        // create a new destination object of the updated contents and isEmpty
+        const newFinish = {
+          contents: draggableId,
+          isEmpty: false,
+        };
+        // update state with new state object
+        setDnDState({
+          // copy in the existing state object
+          ...DnDState,
+          // update the source contents
+          [source.droppableId]: newStart,
+          // update the destination contents
+          [destination.droppableId]: newFinish,
+        });
+      }
     }
   };
   return (

--- a/src/components/pages/VotingPage/DropZone/DropZone.tsx
+++ b/src/components/pages/VotingPage/DropZone/DropZone.tsx
@@ -19,7 +19,7 @@ const DropZone = ({
       {(provided: DroppableProvided, snapshot: DroppableStateSnapshot) => (
         <div
           className={`drop-zone${snapshot.isDraggingOver ? ' drag-over' : ''}${
-            snapshot.draggingFromThisWith ? ' drag-over' : ''
+            snapshot.draggingFromThisWith ? ' drag-from' : ''
           }`}
           ref={provided.innerRef}
           {...provided.droppableProps}

--- a/src/state/DnDState/DnDAtoms.ts
+++ b/src/state/DnDState/DnDAtoms.ts
@@ -1,10 +1,10 @@
 import { atom } from 'recoil';
 
-interface DnDContainerState {
+export interface DnDContainerState {
   [key: string]: ContainerState;
 }
 
-interface ContainerState {
+export interface ContainerState {
   contents: string;
   isEmpty: boolean;
 }

--- a/src/state/DnDState/DnDAtoms.ts
+++ b/src/state/DnDState/DnDAtoms.ts
@@ -1,15 +1,15 @@
 import { atom } from 'recoil';
 
-export interface DnDContainerState {
+interface DnDState {
   [key: string]: ContainerState;
 }
 
-export interface ContainerState {
+interface ContainerState {
   contents: string;
   isEmpty: boolean;
 }
 
-export const initDnDContainerState: DnDContainerState = {
+export const initDnDContainerState: DnDState = {
   'sub-1': { contents: '', isEmpty: true },
   'sub-2': { contents: '', isEmpty: true },
   'sub-3': { contents: '', isEmpty: true },
@@ -18,7 +18,7 @@ export const initDnDContainerState: DnDContainerState = {
   'vote-3': { contents: 'award-3', isEmpty: false },
 };
 
-export const DnDContainerState = atom<DnDContainerState>({
+export const DnDContainerState = atom<DnDState>({
   key: 'DnDContainerState',
   default: initDnDContainerState,
 });


### PR DESCRIPTION
# Fixed Bugs with Dragon Drop Voting

----Description of the feature, what does it solve?----

* [x] Corrected wrong class name being applied to Drop Zone container when a drag was occurring.
* [x] Fixed a bug where the empty dragon would remain if a user started a drag and then dropped the dragon outside a valid drop zone.
* [x] Corrected `onDragEnd()` to properly handle logic if a destination was undefined.
* [x] Added type checking to `useRecoilState` hook for `DnDState` in `CastVoteContainer.tsx`.


