### PR TITLE
Added some bugfixes and refactors, explained in PR.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
     "react-spinners": "^0.9.0",
+    "react-zoom-pan-pinch": "^1.6.1",
     "recoil": "^0.1.2",
     "typescript": "^4.1.2",
     "web-vitals": "^0.2.4"

--- a/src/api/Submissions/imageLoader.ts
+++ b/src/api/Submissions/imageLoader.ts
@@ -6,8 +6,8 @@ export interface SubItem {
   userId: number;
   username: string;
   image: string;
+  src: string;
   pages?: string;
-  src?: string;
 }
 
 export const getImageFromS3 = async (sub: SubItem): Promise<SubItem> => {

--- a/src/api/Submissions/index.ts
+++ b/src/api/Submissions/index.ts
@@ -1,3 +1,4 @@
-export * from './submissions';
-export * from './results';
+export * from './imageLoader';
 export type { SubItem } from './imageLoader';
+export * from './results';
+export * from './submissions';

--- a/src/components/common/AuthModal/LoginForm/LoginForm.tsx
+++ b/src/components/common/AuthModal/LoginForm/LoginForm.tsx
@@ -52,6 +52,7 @@ const LoginForm = (props: Modal.ModalComponentProps): React.ReactElement => {
           <Input
             name="email"
             label="Codename"
+            type="email"
             errors={errors}
             register={register}
             rules={{ required: 'Please enter your email!' }}

--- a/src/components/common/AuthModal/SignupForm/SignupForm.tsx
+++ b/src/components/common/AuthModal/SignupForm/SignupForm.tsx
@@ -76,6 +76,7 @@ const SignupForm = (props: Modal.ModalComponentProps): React.ReactElement => {
             <Input
               name="email"
               label="Email"
+              type="email"
               errors={errors}
               register={register}
               rules={{

--- a/src/components/common/FullscreenImage/FullscreenImage.tsx
+++ b/src/components/common/FullscreenImage/FullscreenImage.tsx
@@ -40,7 +40,6 @@ const FullscreenImage = (props: FullscreenImageProps): React.ReactElement => {
 };
 
 interface FullscreenImageProps extends Submissions.SubItem {
-  src: string;
   isVisible: boolean;
   setIsVisible: React.Dispatch<SetStateAction<boolean>>;
 }

--- a/src/components/common/FullscreenImage/FullscreenImage.tsx
+++ b/src/components/common/FullscreenImage/FullscreenImage.tsx
@@ -1,0 +1,54 @@
+import React, { SetStateAction } from 'react';
+import { MdClose, MdZoomIn, MdZoomOut, MdZoomOutMap } from 'react-icons/md';
+import { TransformComponent, TransformWrapper } from 'react-zoom-pan-pinch';
+import { Submissions } from '../../../api';
+
+const FullscreenImage = (props: FullscreenImageProps): React.ReactElement => {
+  const closeModal = () => {
+    props.setIsVisible(false);
+  };
+
+  return props.isVisible ? (
+    <TransformWrapper>
+      {({ zoomIn, zoomOut, resetTransform }: TransformProps) => (
+        <div className="fullscreen-image">
+          <div className="close-button">
+            <MdClose onClick={closeModal} />
+          </div>
+          <div className="img-wrapper">
+            <TransformComponent>
+              <img src={props.src} alt="Submission displayed fullscreen" />
+            </TransformComponent>
+          </div>
+          <div className="controls">
+            <button onClick={zoomOut}>
+              <MdZoomOut />
+            </button>
+            <button onClick={resetTransform}>
+              <MdZoomOutMap />
+            </button>
+            <button onClick={zoomIn}>
+              <MdZoomIn />
+            </button>
+          </div>
+        </div>
+      )}
+    </TransformWrapper>
+  ) : (
+    <></>
+  );
+};
+
+interface FullscreenImageProps extends Submissions.SubItem {
+  src: string;
+  isVisible: boolean;
+  setIsVisible: React.Dispatch<SetStateAction<boolean>>;
+}
+
+interface TransformProps {
+  zoomIn: () => void;
+  zoomOut: () => void;
+  resetTransform: () => void;
+}
+
+export default FullscreenImage;

--- a/src/components/common/FullscreenImage/FullscreenImage.tsx
+++ b/src/components/common/FullscreenImage/FullscreenImage.tsx
@@ -40,6 +40,7 @@ const FullscreenImage = (props: FullscreenImageProps): React.ReactElement => {
 };
 
 interface FullscreenImageProps extends Submissions.SubItem {
+  src: string;
   isVisible: boolean;
   setIsVisible: React.Dispatch<SetStateAction<boolean>>;
 }

--- a/src/components/common/FullscreenImage/index.ts
+++ b/src/components/common/FullscreenImage/index.ts
@@ -1,0 +1,1 @@
+export { default as FullscreenImage } from './FullscreenImage';

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -16,6 +16,7 @@ const Header = (): React.ReactElement => {
   const menuItems = useMemo<headerItems[]>(() => {
     const navItems = [{ link: '/', text: 'Home' }];
     if (gameActive) navItems.push({ link: '/game', text: 'Game' });
+    navItems.push({ link: '/results', text: 'Results' });
     if (isLogged) navItems.push({ link: '/logout', text: 'Sign Out' });
     return navItems;
   }, [isLogged]);

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -33,6 +33,7 @@ const Input = ({
           type={inputType}
           ref={register && register(rules)}
           autoComplete="off"
+          autoCapitalize="off"
           placeholder={placeholder}
           {...rest}
         />
@@ -58,7 +59,8 @@ const Input = ({
   );
 };
 
-interface InputProps {
+interface InputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {
   name: string;
   label: string;
   register: UseFormMethods['register'];

--- a/src/components/common/SubCard/SubCard.tsx
+++ b/src/components/common/SubCard/SubCard.tsx
@@ -28,7 +28,6 @@ const SubCard = ({
 };
 
 interface SubCardProps extends Submissions.SubItem {
-  src: string;
   canPreview?: boolean;
   onModalOpen?: () => void;
 }

--- a/src/components/common/SubCard/SubCard.tsx
+++ b/src/components/common/SubCard/SubCard.tsx
@@ -1,13 +1,7 @@
 import React, { useState } from 'react';
-import { Submissions } from '../../../api';
-import { Modal } from '../Modal';
-
 import { BsArrowsFullscreen } from 'react-icons/bs';
-
-interface SubCardProps extends Submissions.SubItem {
-  canPreview?: boolean;
-  onModalOpen?: () => void;
-}
+import { Submissions } from '../../../api';
+import { FullscreenImage } from '../FullscreenImage';
 
 const SubCard = ({
   canPreview = true,
@@ -23,24 +17,20 @@ const SubCard = ({
 
   return (
     <div className="sub-card" style={{ backgroundImage: `url(${sub.src})` }}>
-      <Modal.Component
-        visible={showModal}
-        setVisible={setShowModal}
-        component={() => <ModalImage {...sub} />}
-        closable={true}
-        title={sub.username}
+      <FullscreenImage
+        {...sub}
+        isVisible={showModal}
+        setIsVisible={setShowModal}
       />
       {canPreview && <BsArrowsFullscreen onClick={modalOpenHandler} />}
     </div>
   );
 };
 
-const ModalImage = (props: Submissions.SubItem) => {
-  return (
-    <div className="modal-image">
-      <img src={props.src} alt="" />
-    </div>
-  );
-};
+interface SubCardProps extends Submissions.SubItem {
+  src: string;
+  canPreview?: boolean;
+  onModalOpen?: () => void;
+}
 
 export default SubCard;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -2,6 +2,7 @@ export { AuthModal } from './AuthModal';
 export { Checkbox } from './Checkbox';
 export { ComingSoon } from './ComingSoon';
 export { Countdown } from './Countdown';
+export { FullscreenImage } from './FullscreenImage';
 export { Header } from './Header';
 export { Histogram } from './Histogram';
 export { InfoHoverTip } from './InfoHoverTip';

--- a/src/state/top3State/top3Atoms.ts
+++ b/src/state/top3State/top3Atoms.ts
@@ -1,19 +1,7 @@
 import { atom } from 'recoil';
 import { Submissions } from '../../api';
 
-// const makeTop3 = (userId: number) => {
-//   const src = 'https://i.redd.it/54awv7jxe4e41.jpg';
-//   return [...new Array(3)].map((x, i) => ({
-//     id: i + 1,
-//     image: '',
-//     username: 'TestUsername',
-//     userId: userId,
-//     src: src,
-//   }));
-// };
-
 const top3InitState = null;
-// const top3InitState: Submissions.SubItem[] = makeTop3(14);
 
 export const top3List = atom<Submissions.SubItem[] | null>({
   key: 'top3List',

--- a/src/state/top3State/top3Selectors.ts
+++ b/src/state/top3State/top3Selectors.ts
@@ -13,7 +13,7 @@ export const getReadCount = selector<number>({
 // This hasn't been used yet, and is mostly here to serve as an example
 // of how to use the powerful selectorFamily syntax
 export const getTop3ByIndex = selectorFamily<
-  Submissions.SubItem | null, // The return value of the getter, subission or null
+  Submissions.SubItem | null, // The return value of the getter, submission or null
   number // The parameter passed into the getter, here a numbered array index
 >({
   key: 'top3ByIndex',

--- a/src/styles/components/common/fullscreenImage.scss
+++ b/src/styles/components/common/fullscreenImage.scss
@@ -1,0 +1,73 @@
+.fullscreen-image {
+  background-color: #0008;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  max-width: 100vw;
+  height: 100vh;
+  max-height: 100vh;
+  z-index: 150;
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+
+  .close-button {
+    position: absolute;
+    top: 1vh;
+    right: 1vh;
+    z-index: 155;
+    font-size: 5vh;
+    color: $white;
+    cursor: pointer;
+    opacity: 0.6;
+    transition: opacity 0.15s ease-in;
+    &:hover {
+      opacity: 1;
+      transition: opacity 0.15s ease-in;
+    }
+  }
+
+  .img-wrapper {
+    height: 90vh;
+    width: 100vw;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+
+    img {
+      max-width: 100%;
+      max-height: 90vh;
+    }
+  }
+
+  .controls {
+    height: 10vh;
+    width: 100%;
+    background-color: #0005;
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    justify-content: center;
+
+    button {
+      background: none;
+      border: none;
+      color: $white;
+      font-size: 6vh;
+      height: 6vh;
+      overflow: hidden;
+      cursor: pointer;
+      opacity: 0.6;
+      transition: opacity 0.15s ease-in;
+      &:hover {
+        opacity: 1;
+        transition: opacity 0.15s ease-in;
+      }
+      &:not(:last-of-type) {
+        margin-right: 5px;
+      }
+    }
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -27,3 +27,4 @@
 @import './components/common/termsOfService.scss';
 @import './components/common/countdown.scss';
 @import './components/common/authToggle.scss';
+@import './components/common/fullscreenImage.scss';

--- a/yarn.lock
+++ b/yarn.lock
@@ -9977,6 +9977,11 @@ react-spinners@^0.9.0:
   dependencies:
     "@emotion/core" "^10.0.15"
 
+react-zoom-pan-pinch@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/react-zoom-pan-pinch/-/react-zoom-pan-pinch-1.6.1.tgz#da16267c258ab37e8ebcdc7c252794a9633e91ec"
+  integrity sha512-J2eM0gZ04XiUWvmKZrOhSAB2zjyoK7kw2POIeN1X0yTTlmp6HPGV0zYfjnlkhgt8nQwpvXAbsF/oAnkuiwk1kA==
+
 react@^16.13.1:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"


### PR DESCRIPTION
# UX Refactors

This patch is aimed at refactoring certain UX specs to make the app more enjoyable for users as well as add credibility.

- (Hopefully!) fixed bug where iPhones auto-filled a username instead of an email address
  - This was fixed by adding an `email` type to all email fields
  - This has the added benefit of displaying the proper keyboard for mobile users! <- this is huge!
- Turned off auto-capitalize on the inputs (this was only an issue on certain browsers)
- Added the 'Results' page back into the navbar

## The `FullscreenImage` Component

This also adds a new `common` component that should (hopefully!) improve UX as well! This component is a new modal that fills the screen with a black background and displays an image at `90vh` (to account for the 10vh controls). The image is zoomable/pannable/pinchable thanks to the `react-zoom-pan-pinch` library! There is a bar on the bottom that has controls for zooming in/out as well as resetting the zoom. There's also a close button. The modal doesn't have nice display animations like the other modal that fades in, although we can add those in later if we wish.

> This patch has a new library installed so make sure to run `yarn` after you pull!
