### PR TITLE
Bugfix/show password

### DIFF
--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -38,6 +38,7 @@ const Input = ({
         />
         {showPassword ? (
           <button
+            type="button"
             className="show-hide-btn"
             tabIndex={-1} // Prevents button from being selected while tabbing
             onClick={toggleHiddenPassword}


### PR DESCRIPTION
# Bug Fix - Show/Hide Password

This PR implements a hotfix on an issue in the signup form's password input field that caused a reveal of a typed password after pressing the enter/return key. 

* [x] Added `type="button"` to the button element. 
