### PR TITLE
Nav menu is now 100% width of page

### DIFF
--- a/src/styles/components/common/header.scss
+++ b/src/styles/components/common/header.scss
@@ -4,8 +4,6 @@ header {
   padding: 1rem 2rem;
   color: $white;
 
-  // Create a box shadow to create seperation from the drop down nav menu
-
   h2 {
     font-family: $display-font;
     font-size: 2.4rem;
@@ -43,7 +41,6 @@ header {
   @media screen and (min-width: $tablet) {
     // At higher screen sizes, move the header position back so the nav manu can show on top of it
     z-index: 1;
-    box-shadow: none;
   }
 }
 

--- a/src/styles/components/common/header.scss
+++ b/src/styles/components/common/header.scss
@@ -4,6 +4,8 @@ header {
   padding: 1rem 2rem;
   color: $white;
 
+  // Create a box shadow to create seperation from the drop down nav menu
+
   h2 {
     font-family: $display-font;
     font-size: 2.4rem;
@@ -41,6 +43,7 @@ header {
   @media screen and (min-width: $tablet) {
     // At higher screen sizes, move the header position back so the nav manu can show on top of it
     z-index: 1;
+    box-shadow: none;
   }
 }
 
@@ -103,6 +106,14 @@ header {
   // Add a rounder edge to the mobile menu
   border-radius: 0 0 0 4px;
   overflow: hidden;
+  // Width = 100% on mobile so that left handed users and single handed users have an easier way to access the nav menu
+  width: 100%;
+
+  @media screen and (min-width: $mid) {
+    // Min-width will allow the nav menu to be a small drop down in the top right hand corner of the page to conserve space
+    // which will only be present on desktops & tablets
+    width: unset;
+  }
 
   // Change the menu at larger screens to be positioned inside of the header by making the
   // flexbox flow into a row rather than a column, and positioning the menu to the bottom
@@ -136,10 +147,13 @@ header {
       padding: $vertical-padding 2rem $vertical-padding + 0.2rem; // add slightly more space on the bottoms
       transition: all 0.2s ease-in-out;
 
+      border-top: 1px solid #0003;
+
       @media screen and (min-width: $tablet) {
         // Lower the left/right padding when the menu is a row
         padding: $vertical-padding 0;
         margin-left: 1.5rem;
+        border-top: none;
       }
       @media screen and (min-width: $large) {
         padding: $vertical-padding 1rem;


### PR DESCRIPTION
# Mobile Nav Menu

The mobile nav menu now fits the entire width of the users screen to assist left handed users and single handed users.

Borders were also added to the drop down nav menu clarifying the nav items boundaries.
