### PR TITLE
removed white text color on prompt box making text invisible

### DIFF
--- a/src/styles/components/pages/landingPages/landingPage.scss
+++ b/src/styles/components/pages/landingPages/landingPage.scss
@@ -29,11 +29,6 @@
     text-align: center;
   }
   p {
-    margin: 2rem auto;
-    font-family: $text-font;
-    color: $white;
-    font-size: 1.8rem;
-    line-height: 2.5rem;
     a {
       color: $white;
       font-weight: 500;


### PR DESCRIPTION

# Bug Fix - Prompt Box Text on Landing Page

Changes made to styles for Landing Page that fixes a bug where Prompt Box text was invisible

- [x] Removed old styling rules for landing page that do not apply after recent refactors. This includes a rule that changed the text on the prompt box to the same color as the box background rendering the text invisible
