### PR TITLE
added small amount of padding to drop-zones for user feedback

### DIFF
--- a/src/styles/components/pages/votingPages/dropZone.scss
+++ b/src/styles/components/pages/votingPages/dropZone.scss
@@ -16,3 +16,7 @@
 .dragon-bank .drop-zone {
   width: 33%;
 }
+
+.drop-bank .drop-zone {
+  padding: 0.5rem;
+}


### PR DESCRIPTION
# Minor Style Update to Dragon Drop voting

Adds a small amount of padding (0.5rem) to drop zone containers in the submission bank on the voting page. This should give users a little bit more visual feedback on where the dragon will be dropped off during a drag event.

